### PR TITLE
Fix cast in AnchorLayout.as to use correct interface

### DIFF
--- a/source/feathers/layout/AnchorLayout.as
+++ b/source/feathers/layout/AnchorLayout.as
@@ -682,7 +682,7 @@ package feathers.layout
 		 */
 		protected function positionHorizontally(item:ILayoutDisplayObject, layoutData:AnchorLayoutData, boundsX:Number, boundsY:Number, viewPortWidth:Number, viewPortHeight:Number):void
 		{
-			var uiItem:IFeathersControl = item as IFeathersControl;
+			var uiItem:IMeasureDisplayObject = item as IMeasureDisplayObject;
 			var percentWidth:Number = layoutData.percentWidth;
 			if(percentWidth === percentWidth) //!isNaN
 			{
@@ -835,7 +835,7 @@ package feathers.layout
 		 */
 		protected function positionVertically(item:ILayoutDisplayObject, layoutData:AnchorLayoutData, boundsX:Number, boundsY:Number, viewPortWidth:Number, viewPortHeight:Number):void
 		{
-			var uiItem:IFeathersControl = item as IFeathersControl;
+			var uiItem:IMeasureDisplayObject = item as IMeasureDisplayObject;
 			var percentHeight:Number = layoutData.percentHeight;
 			if(percentHeight === percentHeight) //!isNaN
 			{


### PR DESCRIPTION
positionVertically() and positionHorizintally() should cast the `item` to IMeasureDisplayObject instead of IFeathersControl, since they do not utilize anything from that interface.

Since IFeathersControl inherits IMeasureDisplayObject this works, however this fix allows custom classes to be layouted via AnchorLayout as well (e.g. ImageSkin) wihtout the full FeathersControl implementation.