### PR TITLE
Fix Fade.createFadeInTransition bug when both newScreen and oldScreen passed

### DIFF
--- a/source/feathers/motion/Fade.as
+++ b/source/feathers/motion/Fade.as
@@ -171,7 +171,7 @@ package feathers.motion
 					{
 						oldScreen.alpha = 1;
 					}
-					var tween:FadeTween = new FadeTween(newScreen, oldScreen, duration, ease, onComplete, tweenProperties);
+					var tween:FadeTween = new FadeTween(newScreen, null, duration, ease, onComplete, tweenProperties);
 				}
 				else
 				{


### PR DESCRIPTION
Originally, newScreen and oldScreen were passed, resulting in a crossfade effect.
Now, only newScreen is passed, resulting in a fade in.